### PR TITLE
Remove unnecessary json dependency

### DIFF
--- a/square_connect.gemspec
+++ b/square_connect.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.9"
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
-  s.add_runtime_dependency 'json', '~> 1.8', '>= 1.8.3'
 
   s.add_development_dependency 'rspec', '~> 3.4', '>= 3.4.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'


### PR DESCRIPTION
Closes #36 

JSON 2 is pretty much required now for full JSON RFC compliance and compatibility with ruby 2.4.