### PR TITLE
Fix get_v1_batch_token_from_headers

### DIFF
--- a/lib/square_connect/api_client.rb
+++ b/lib/square_connect/api_client.rb
@@ -386,7 +386,7 @@ module SquareConnect
     # @param [Hash] headers hash with response headers
     # @return [String] batch_token or nil if no token is present
     def get_v1_batch_token_from_headers(headers)
-      if headers.is_a?(Hash) && headers.has_key?('Link')
+      if headers.respond_to?(:has_key?) && headers.has_key?('Link')
         match = /^<([^>]+)>;rel='next'$/.match(headers['Link'])
         if match
           uri = URI.parse(match[1])


### PR DESCRIPTION
Following instructions in the readme like so:

```
results, _status, headers = api.list_payments_with_http_info(location_id, options)
```

Headers is not a hash. So `headers.is_a?(Hash)` is always false and the token fails to be extracted. This PR fixes that.