### PR TITLE
Specify api key prefix for renew_token

### DIFF
--- a/docs/OAuthApi.md
+++ b/docs/OAuthApi.md
@@ -72,7 +72,7 @@ SquareConnect.configure do |config|
   # Configure API key authorization: oauth2ClientSecret
   config.api_key['Authorization'] = 'YOUR API KEY'
   # Uncomment the following line to set a prefix for the API key, e.g. 'Bearer' (defaults to nil)
-  #config.api_key_prefix['Authorization'] = 'Bearer'
+  config.api_key_prefix['Authorization'] = 'Client'
 end
 
 api_instance = SquareConnect::OAuthApi.new


### PR DESCRIPTION
This detail is in the description, but why not to help developer on example.